### PR TITLE
Add support for simulation

### DIFF
--- a/config/panda_gripper_controllers_sim.yaml
+++ b/config/panda_gripper_controllers_sim.yaml
@@ -1,0 +1,13 @@
+ controller_list:
+  - name: position_joint_trajectory_controller
+    action_ns: follow_joint_trajectory
+    type: FollowJointTrajectory
+    default: true
+    joints:
+      - panda_joint1
+      - panda_joint2
+      - panda_joint3
+      - panda_joint4
+      - panda_joint5
+      - panda_joint6
+      - panda_joint7

--- a/launch/move_group_sim.launch
+++ b/launch/move_group_sim.launch
@@ -1,0 +1,76 @@
+<launch>
+
+  <include file="$(find panda_moveit_config)/launch/planning_context.launch"/>
+
+  <arg name="pipeline" default="ompl" />
+
+  <!-- GDB Debug Option -->
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg     if="$(arg debug)" name="launch_prefix"
+	   value="gdb -x $(find panda_moveit_config)/launch/gdb_settings.gdb --ex run --args" />
+
+  <!-- Verbose Mode Option -->
+  <arg name="info" default="$(arg debug)" />
+  <arg unless="$(arg info)" name="command_args" value="" />
+  <arg     if="$(arg info)" name="command_args" value="--debug" />
+
+  <!-- move_group settings -->
+  <arg name="allow_trajectory_execution" default="true"/>
+  <arg name="fake_execution" default="false"/>
+  <arg name="max_safe_path_cost" default="1"/>
+  <arg name="jiggle_fraction" default="0.05" />
+  <arg name="publish_monitored_planning_scene" default="true"/>
+
+  <!-- Planning Functionality -->
+  <include ns="move_group" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
+    <arg name="pipeline" value="$(arg pipeline)" />
+  </include>
+
+  <!-- Trajectory Execution Functionality -->
+  <include ns="move_group" file="$(find panda_moveit_config)/launch/trajectory_execution_sim.launch.xml" if="$(arg allow_trajectory_execution)">
+    <arg name="moveit_manage_controllers" value="true" />
+    <arg name="moveit_controller_manager" value="panda_gripper" if="$(eval not arg('fake_execution'))"/>x
+    <arg name="moveit_controller_manager" value="fake" if="$(arg fake_execution)"/>
+  </include>
+
+  <!-- Sensors Functionality -->
+  <include ns="move_group" file="$(find panda_moveit_config)/launch/sensor_manager.launch.xml" if="$(arg allow_trajectory_execution)">
+    <arg name="moveit_sensor_manager" value="panda" />
+  </include>
+
+  <!-- Start the actual move_group node/action server -->
+  <node name="move_group" launch-prefix="$(arg launch_prefix)" pkg="moveit_ros_move_group" type="move_group" respawn="false" output="screen" args="$(arg command_args)">
+    <!-- Set the display variable, in case OpenGL code is used internally -->
+    <env name="DISPLAY" value="$(optenv DISPLAY :0)" />
+
+    <param name="allow_trajectory_execution" value="$(arg allow_trajectory_execution)"/>
+    <param name="max_safe_path_cost" value="$(arg max_safe_path_cost)"/>
+    <param name="jiggle_fraction" value="$(arg jiggle_fraction)" />
+
+    <!-- load these non-default MoveGroup capabilities -->
+    <!--
+    <param name="capabilities" value="
+                  a_package/AwsomeMotionPlanningCapability
+                  another_package/GraspPlanningPipeline
+                  " />
+    -->
+
+    <!-- inhibit these default MoveGroup capabilities -->
+    <!--
+    <param name="disable_capabilities" value="
+                  move_group/MoveGroupKinematicsService
+                  move_group/ClearOctomapService
+                  " />
+    -->
+
+    <!-- Publish the planning scene of the physical robot so that rviz plugin can know actual robot -->
+    <param name="planning_scene_monitor/publish_planning_scene" value="$(arg publish_monitored_planning_scene)" />
+    <param name="planning_scene_monitor/publish_geometry_updates" value="$(arg publish_monitored_planning_scene)" />
+    <param name="planning_scene_monitor/publish_state_updates" value="$(arg publish_monitored_planning_scene)" />
+    <param name="planning_scene_monitor/publish_transforms_updates" value="$(arg publish_monitored_planning_scene)" />
+
+    <remap from="/joint_states" to="/joint_states_desired" />
+  </node>
+
+</launch>

--- a/launch/panda_control_moveit_rviz_sim.launch
+++ b/launch/panda_control_moveit_rviz_sim.launch
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<launch>
+  <!-- If needed, broadcast static tf for robot root -->
+  <node pkg="tf2_ros" type="static_transform_publisher" name="virtual_joint_broadcaster_1" args="0 0 0 0 0 0 world panda_link0" />
+
+  <!-- Broadcast a static tf transform for hand-eye calibration -->
+  <!-- <node pkg="tf2_ros" type="static_transform_publisher" name="virtual_joint_broadcaster_2" args="0.0512008 -0.0094141 0.0417049 0.7170629534293602 -0.025008923209280443 0.6965198428440764 0.007441982500551558 /panda_hand /camera_link" /> -->
+
+  <arg name="launch_rviz" default="false" />
+  <arg name="rviz_command_args" default="" />
+
+  <include file="$(find panda_moveit_config)/launch/move_group_sim.launch"/>
+
+  <!-- <include file="$(find panda_moveit_config)/launch/moveit_rviz.launch" if="$(arg launch_rviz)" > -->
+    <!-- <arg name="rviz_command_args" value="$(arg rviz_command_args)" /> -->
+  <!-- </include> -->
+</launch>

--- a/launch/panda_gripper_moveit_controller_manager_sim.launch.xml
+++ b/launch/panda_gripper_moveit_controller_manager_sim.launch.xml
@@ -1,0 +1,7 @@
+ <launch>
+  <!-- Set the param that trajectory_execution_manager needs to find the controller plugin -->
+  <arg name="moveit_controller_manager" default="moveit_simple_controller_manager/MoveItSimpleControllerManager" />
+  <param name="moveit_controller_manager" value="$(arg moveit_controller_manager)"/>
+  <!-- load controller_list -->
+  <rosparam file="$(find panda_moveit_config)/config/panda_gripper_controllers_sim.yaml"/>
+ </launch>

--- a/launch/trajectory_execution_sim.launch.xml
+++ b/launch/trajectory_execution_sim.launch.xml
@@ -1,0 +1,20 @@
+<launch>
+
+  <!-- This file makes it easy to include the settings for trajectory execution  -->
+
+  <!-- Flag indicating whether MoveIt! is allowed to load/unload  or switch controllers -->
+  <arg name="moveit_manage_controllers" default="true"/>
+  <param name="moveit_manage_controllers" value="$(arg moveit_manage_controllers)"/>
+
+  <!-- When determining the expected duration of a trajectory, this multiplicative factor is applied to get the allowed duration of execution -->
+  <param name="trajectory_execution/allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
+  <!-- Allow more than the expected execution time before triggering a trajectory cancel (applied after scaling) -->
+  <param name="trajectory_execution/allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
+  <!-- Allowed joint-value tolerance for validation that trajectory's first point matches current robot state -->
+  <param name="trajectory_execution/allowed_start_tolerance" value="0.01"/> <!-- default 0.01 -->
+
+  <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
+  <arg name="moveit_controller_manager" default="panda" />
+  <include file="$(find panda_moveit_config)/launch/$(arg moveit_controller_manager)_moveit_controller_manager_sim.launch.xml" />
+
+</launch>


### PR DESCRIPTION
Add bunch of xml launch files and configuration yaml to support moveit with https://github.com/hsp-panda/easy_panda_sim.

All the new files ends with `_sim` in order to be easily identified. No files associated to the setup of the real robot have been modified.