### PR TITLE
Disable octomap occupancy feature

### DIFF
--- a/launch/sensor_manager.launch.xml
+++ b/launch/sensor_manager.launch.xml
@@ -3,7 +3,7 @@
   <!-- This file makes it easy to include the settings for sensor managers -->
 
   <!-- Param for kinect config -->
-  <rosparam command="load" file="$(find panda_moveit_config)/config/sensors_kinect_pointcloud.yaml" />
+  <!-- <rosparam command="load" file="$(find panda_moveit_config)/config/sensors_kinect_pointcloud.yaml" /> -->
 
   <!-- Params for the octomap monitor -->
   <!--  <param name="octomap_frame" type="string" value="some frame in which the robot moves" /> -->


### PR DESCRIPTION
As discussed with @fbottarel, we are disabling the octomap-based occupancy check feature (we never used it but the change was left uncommitted in the panda WS).

